### PR TITLE
Update jquery-datagridview.js

### DIFF
--- a/jquery-datagridview/Scripts/jquery-datagridview.js
+++ b/jquery-datagridview/Scripts/jquery-datagridview.js
@@ -265,6 +265,7 @@
                 .text(datagridview.options.resources.getPageText(datagridview));
             let go = $('<button>')
                 .addClass('datagridview-paging-go')
+                .attr('type', 'button')
                 .text(datagridview.options.resources.getGoText(datagridview))
                 .click(function () {
                     datagridview.initiatePaging(page.val() - 1, metaData.rowsPerPage);
@@ -286,6 +287,7 @@
                 .text(datagridview.options.resources.getPageSizeText(datagridview));
             let go = $('<button>')
                 .addClass('datagridview-paging-go')
+                .attr('type', 'button')
                 .text(datagridview.options.resources.getGoText(datagridview))
                 .click(function () {
                     datagridview.initiatePaging(metaData.page, pageSize.val());


### PR DESCRIPTION
the lacking of the attribute type was causing a bug in pages with forms, the buttons "Go" were by default submitting the form