### PR TITLE
bugfix: page buttons should have type button

### DIFF
--- a/jquery-datagridview/Scripts/jquery-datagridview.js
+++ b/jquery-datagridview/Scripts/jquery-datagridview.js
@@ -228,8 +228,8 @@
                     .toggleClass('datagridview-paging-page-active', page == metaData.page)
                     .text(currentPage + 1)
                     .click(function () { datagridview.initiatePaging(currentPage, metaData.rowsPerPage); })
-                    .prop('disabled', metaData.page === currentPage))
-                    .prop('type', 'button');
+                    .prop('disabled', metaData.page === currentPage)
+                    .prop('type', 'button'));
             }
 
             if (metaData.page < metaData.totalPages - 5) {


### PR DESCRIPTION
A misplacement of parenthesis caused the page selection buttons in the footer to not have type button as intended.